### PR TITLE
verificacao de indice 'erro' de array de retorno pra evitar warning quando a api retorna erro

### DIFF
--- a/client/MapiClient.php
+++ b/client/MapiClient.php
@@ -259,7 +259,7 @@ class MapiClient {
 			throw $e;
 	 	} else {
 	 		$arrResult = json_decode($result, true);
-	 		if($arrResult['response']['erro'] == 1){
+	 		if(isset($arrResult['response']['erro']) && $arrResult['response']['erro'] == 1){
 	 			$e = new MapiException(
 	 				array('error_code' => $arrResult['response']['status'],
 						  'error'      => array(


### PR DESCRIPTION
Correção de warning.

Após as últimas modificações de retorno da API o client passou a dar warning em todos os requests pro endpoint de resultado
